### PR TITLE
Add masondelan/selvedge under MCP Servers → Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Tools and integrations that enhance the development workflow and environment man
 
 ### 🔄 Version Control
 
+- [masondelan/selvedge](https://github.com/masondelan/selvedge) - Live capture of *why* AI agents change code. Local SQLite, seven MCP tools including `prior_attempts` (the agent reads prior reasoning before it edits), entity-level history with reasoning. Python 3.10+, MIT. 🖥️ Local.
+
 
 ### 🛠️ Other Tools and Integrations
 


### PR DESCRIPTION
Adding Selvedge to the awesome-mcp list.

Selvedge is an MCP server that AI coding agents call as they work to log structured change events — entity, diff, and reasoning — to a local SQLite database. Unlike post-hoc tools that infer reasoning from the diff, Selvedge captures the agent's intent live, from the same context window that produced the change. As of v0.3.7, the new `prior_attempts` tool lets the agent read the prior reasoning for a file before it edits.

- v0.3.7 latest, pytest/ruff/mypy all green
- MIT, Python 3.10+, `pip install selvedge`
- Seven MCP tools: `log_change`, `diff`, `blame`, `history`, `changeset`, `search`, `prior_attempts`
- Existing listings: PyPI, Glama, Smithery, mcpservers.org
- Glama: https://glama.ai/mcp/servers/masondelan/selvedge
- Smithery: https://smithery.ai/server/masondelan/selvedge
- Website: https://selvedge.sh

Slotted under `### 🔄 Version Control` as the closest semantic fit (structured change-event tracking with reasoning). The section is currently empty — happy to move to Developer Tools if you'd rather keep Version Control reserved for something else.
